### PR TITLE
chore(dev): Unserialization errors are now logged instead of ignored silently

### DIFF
--- a/classes/hypeJunction/Payments/SerializedMetadata.php
+++ b/classes/hypeJunction/Payments/SerializedMetadata.php
@@ -43,7 +43,7 @@ trait SerializedMetadata {
 		if (substr($serialized, 0, 2) === 'z_') {
 			$serialized = base64_decode(substr($serialized, 2));
 		}
-		$value = @unserialize($serialized);
+		$value = unserialize($serialized);
 
 		if ($value !== false) {
 			return $value;


### PR DESCRIPTION
I had a case where unserialization of a metadata value failed because for some reason the value was an array instead of string. Debugging was very difficult because based on the error log nothing was wrong.